### PR TITLE
Add proportioned columns and alignment specifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Add new `predbox` base. These bases are labels for the [Parametric Gridfinity Storage Box by Pred][predbox]
   box labels. It is supported for width 4, 5, 6 and 7, which corresponds to the
   label size corresponding to a storage box of that many gridfinity units.
+- Add fragment `{|}`. This allows you to designate columns between which
+  the text area will be split.
 
 [predbox]: https://www.printables.com/model/543553-gridfinity-storage-box-by-pred-now-parametric
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
   box labels. It is supported for width 4, 5, 6 and 7, which corresponds to the
   label size corresponding to a storage box of that many gridfinity units.
 - Add fragment `{|}`. This allows you to designate columns between which
-  the text area will be split.
+  the text area will be split. You can specify the ratio of column widths
+  by specifying the proportions in the fragment e.g. `{2|1}`.
 
 [predbox]: https://www.printables.com/model/543553-gridfinity-storage-box-by-pred-now-parametric
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,17 @@
 - Add new `predbox` base. These bases are labels for the [Parametric Gridfinity Storage Box by Pred][predbox]
   box labels. It is supported for width 4, 5, 6 and 7, which corresponds to the
   label size corresponding to a storage box of that many gridfinity units.
+- Added alignment specifiers `{<}` and `{>}`. These can only be used at the
+  start of a label column (or label division) and causes the contents of the
+  column to all be left-aligned or right-aligned. For aligning only specific
+  lines in a column, the padding fragment `{...}` can still be used.
 - Add fragment `{|}`. This allows you to designate columns between which
   the text area will be split. You can specify the ratio of column widths
-  by specifying the proportions in the fragment e.g. `{2|1}`.
+  by specifying the proportions in the fragment e.g. `{2|1}`. You can also
+  specify the alignment of the column following the divider within the
+  fragment specification e.g. `{|>}`.
+- Added new option `--column-gap`, that specifies the gap between columns when
+  using the column specification fragment.
 
 [predbox]: https://www.printables.com/model/543553-gridfinity-storage-box-by-pred-now-parametric
 

--- a/src/gflabel/cli.py
+++ b/src/gflabel/cli.py
@@ -202,6 +202,10 @@ def run(argv: list[str] | None = None):
         default=2,
         type=float,
     )
+    parser.add_argument(
+        "--column-gap", help="Gap (in mm) between columns", default=0.4, type=float
+    )
+
     parser.add_argument("-v", "--verbose", help="Verbose output", action="store_true")
     args = parser.parse_args(argv)
 

--- a/src/gflabel/fragments.py
+++ b/src/gflabel/fragments.py
@@ -1096,14 +1096,23 @@ class SplitterFragment(Fragment):
     """Denotes a column edge, where the label should be split."""
 
     _SIIF = r"(\d*(?:\d[.]|[.]\d)?\d*)"  # Parses a simple int or float
-    SPLIT_RE: ClassVar[re.Pattern] = re.compile(f"\{{{_SIIF}\|{_SIIF}}}")
+    SPLIT_RE: ClassVar[re.Pattern] = re.compile(f"\\{{{_SIIF}\\|{_SIIF}([<>]?)}}")
+
+    alignment: str | None
 
     def __init__(
-        self, left: str | None = None, right: str | None = None, *args: list[Any]
+        self,
+        left: str | None = None,
+        right: str | None = None,
+        alignment: str | None = None,
+        *args: list[Any],
     ):
-        self.left = left
-        self.right = right
-        raise NotImplementedError("Splitters currently never be instantiated")
+        assert not args
+        self.left = float(left or 1)
+        self.right = float(right or 1)
+        self.alignment = alignment or None
+        if self.alignment not in {None, "<", ">"}:
+            raise ValueError(f"Unknown alignment specifier: {self.alignment!r}")
 
     def render(self, height: float, maxsize: float, options: RenderOptions) -> Sketch:
         # This should never happen; for now. We might decide to add

--- a/src/gflabel/fragments.py
+++ b/src/gflabel/fragments.py
@@ -1093,7 +1093,7 @@ class _electrical_symbol_fragment(Fragment):
 
 @fragment("|")
 class SplitterFragment(Fragment):
-    """Denotes a column edge, where the label should be split."""
+    """Denotes a column edge, where the label should be split. You can specify relative proportions for the columns, as well as specifying the column alignment."""
 
     _SIIF = r"(\d*(?:\d[.]|[.]\d)?\d*)"  # Parses a simple int or float
     SPLIT_RE: ClassVar[re.Pattern] = re.compile(f"\\{{{_SIIF}\\|{_SIIF}([<>]?)}}")
@@ -1118,6 +1118,16 @@ class SplitterFragment(Fragment):
         # This should never happen; for now. We might decide to add
         # options for rendered dividers later.
         raise NotImplementedError("Splitters should never be rendered")
+
+
+@fragment("<", ">")
+class AlignmentFragment(Fragment):
+    """Only used at the start of a single label or column. Specifies that all lines in the area should be left or right aligned. Invalid when specified elsewhere."""
+
+    def __init__(self, *args):
+        raise InvalidFragmentSpecification(
+            "Got Alignment fragment ({<} or {>}) not at the start of a label; for selective alignment please pad with {...}, or specify alignment in column division."
+        )
 
 
 if __name__ == "__main__":

--- a/src/gflabel/fragments.py
+++ b/src/gflabel/fragments.py
@@ -1095,7 +1095,8 @@ class _electrical_symbol_fragment(Fragment):
 class SplitterFragment(Fragment):
     """Denotes a column edge, where the label should be split."""
 
-    SPLIT_RE: ClassVar[re.Pattern] = re.compile(r"\{(\d*)\|(\d*)}")
+    _SIIF = r"(\d*(?:\d[.]|[.]\d)?\d*)"  # Parses a simple int or float
+    SPLIT_RE: ClassVar[re.Pattern] = re.compile(f"\{{{_SIIF}\|{_SIIF}}}")
 
     def __init__(
         self, left: str | None = None, right: str | None = None, *args: list[Any]

--- a/src/gflabel/fragments.py
+++ b/src/gflabel/fragments.py
@@ -12,7 +12,7 @@ import zipfile
 from abc import ABCMeta, abstractmethod
 from collections.abc import Callable
 from math import cos, radians, sin
-from typing import Any, Iterable, NamedTuple, Type, TypedDict
+from typing import Any, ClassVar, Iterable, NamedTuple, Type, TypedDict
 
 from build123d import (
     Align,
@@ -1089,6 +1089,25 @@ class _electrical_symbol_fragment(Fragment):
         bb = _sketch.sketch.bounding_box()
         # Resize this to match the requested height, and to be centered
         return _sketch.sketch.translate(-bb.center()).scale(height / bb.size.Y)
+
+
+@fragment("|")
+class SplitterFragment(Fragment):
+    """Denotes a column edge, where the label should be split."""
+
+    SPLIT_RE: ClassVar[re.Pattern] = re.compile(r"\{(\d*)\|(\d*)}")
+
+    def __init__(
+        self, left: str | None = None, right: str | None = None, *args: list[Any]
+    ):
+        self.left = left
+        self.right = right
+        raise NotImplementedError("Splitters currently never be instantiated")
+
+    def render(self, height: float, maxsize: float, options: RenderOptions) -> Sketch:
+        # This should never happen; for now. We might decide to add
+        # options for rendered dividers later.
+        raise NotImplementedError("Splitters should never be rendered")
 
 
 if __name__ == "__main__":

--- a/src/gflabel/label.py
+++ b/src/gflabel/label.py
@@ -133,7 +133,11 @@ class LabelRenderer:
 
         # Calculate column widths
         total_proportions = sum(column_proportions)
-        column_widths = [x * area.X / total_proportions for x in column_proportions]
+        column_gaps_width = self.opts.column_gap * (len(columns) - 1)
+        column_widths = [
+            x * (area.X - column_gaps_width) / total_proportions
+            for x in column_proportions
+        ]
         logger.debug(f"{column_widths=}")
         logger.debug(f"{column_proportions=}")
 
@@ -145,7 +149,7 @@ class LabelRenderer:
                         column_spec, Vector(X=width, Y=area.Y)
                     ).locate(Location((x + (width / 2), 0)))
                 )
-                x += width
+                x += width + self.opts.column_gap
 
         return sketch.sketch
         # return self._do_multiline_render(spec, area)

--- a/src/gflabel/label.py
+++ b/src/gflabel/label.py
@@ -131,6 +131,9 @@ class LabelRenderer:
 
             columns.append(label)
 
+        if not column_proportions:
+            column_proportions = [1]
+
         # Calculate column widths
         total_proportions = sum(column_proportions)
         column_gaps_width = self.opts.column_gap * (len(columns) - 1)

--- a/src/gflabel/options.py
+++ b/src/gflabel/options.py
@@ -48,6 +48,7 @@ class RenderOptions(NamedTuple):
     # height so that they can fit. Is this allowed, or will they scale
     # like everything else?
     allow_overheight: bool = True
+    column_gap: float = 0.4
 
     @classmethod
     def from_args(cls, args: argparse.Namespace) -> RenderOptions:
@@ -63,4 +64,5 @@ class RenderOptions(NamedTuple):
                 font_height_exact=not args.font_size_maximum,
             ),
             allow_overheight=not args.no_overheight,
+            column_gap=args.column_gap,
         )


### PR DESCRIPTION
- Add `{|}` to specify a column. Label specification will be divided into left and right sides. The basic usage somewhat overlaps with label division specification (except can divide only one area). You can specify proportions for each column e.g. `{3|2}` to have the left column be 3/5 of the area and the right to be 2/5 of the area. You can also specify multiple divisions, and the total label area will be divided up proportionally.
- Added alignment specifiers `{<}` and `{>}`. These cause all lines in the label to be left-aligned, or right aligned. It's an error to specify these anywhere except the start of a label (or a column). This is a convenient alternative to adding a spacer fragment (`{...}`) at the start or end of every line, and gives identical results.