### PR TITLE
Allow --height override on all bases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # GFLabel 0.2.dev
 
+- All labels can have their height altered with `--height`. Please be
+  aware that this will likely make them incompatible with the label
+  standard, so only use this if you intend to diverge from the standard.
 - The "webb" base type has been renamed to "cullenect", to reflect the
   label system being renamed. "webb" will still work, but usage is
   deprecated. The fragment `{webbolt}` has been renamed to

--- a/src/gflabel/bases/cullenect.py
+++ b/src/gflabel/bases/cullenect.py
@@ -24,7 +24,7 @@ from build123d import (
 from . import LabelBase
 
 
-def body_v11() -> LabelBase:
+def body_v11(height_mm: float | None = None) -> LabelBase:
     """
     Generate a Webb-style label body
 
@@ -37,7 +37,7 @@ def body_v11() -> LabelBase:
             label_area: A vector describing the width, height of the usable area.
     """
     width = 36.4
-    height = 11
+    height = height_mm or 11.0
     depth = 1
     with BuildPart() as part:
         with BuildSketch():
@@ -120,9 +120,9 @@ def body_v11() -> LabelBase:
     return LabelBase(part.part, Vector(36.4, 11))
 
 
-def body_v200(width_u: int) -> LabelBase:
+def body_v200(width_u: int, height_mm: float | None = None) -> LabelBase:
     width = 42 * width_u - 6
-    height = 11
+    height = height_mm or 11
     depth = 1.2
     with BuildPart() as part:
         # Label body
@@ -166,7 +166,9 @@ def body_v200(width_u: int) -> LabelBase:
     return LabelBase(part.part, Vector(width, height))
 
 
-def body(version: str = "latest", width: int | None = None) -> LabelBase:
+def body(
+    version: str = "latest", width: int | None = None, height_mm: float | None = None
+) -> LabelBase:
     """
     Generate a Webb-style label body
 
@@ -193,9 +195,9 @@ def body(version: str = "latest", width: int | None = None) -> LabelBase:
             )
 
         assert width is None or width == 1
-        return body_v11()
+        return body_v11(height_mm=height_mm)
     elif version == "v2.0.0":
-        return body_v200(width or 1)
+        return body_v200(width_u=width or 1, height_mm=height_mm)
 
     raise RuntimeError(
         "Error: Got to end of cullenect generation without choosing a body!"

--- a/src/gflabel/bases/modern.py
+++ b/src/gflabel/bases/modern.py
@@ -32,7 +32,7 @@ from build123d import (
 from . import LabelBase
 
 
-def body(width: int) -> LabelBase:
+def body(width: int, height_mm: float | None = None) -> LabelBase:
     """
     Generate a Modern-Gridfinity-Case label body
 
@@ -62,7 +62,7 @@ def body(width: int) -> LabelBase:
         sys.exit(f"Error: Do not know how wide to create 'modern' label for {width} u")
 
     W = KNOWN_WIDTHS[width] - EXTRA_WIDTH_TOL
-    H = 22.117157  # I cannot work out the basis for this value
+    H = height_mm or 22.117157  # I cannot work out the basis for this value
     depth = 2.2
 
     # Label constructed by angled extrusion of inner sketch


### PR DESCRIPTION
For bases with a standard height, this could leave them incompatible with the standard, but is useful if the user has intentionally tweaked this and wants to print their own, compatible labels.

As suggested by @Marus in https://github.com/ndevenish/gflabel/pull/14#issuecomment-2565744767.