### PR TITLE
Allow overriding width for all labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # GFLabel 0.2.dev
 
+- All labels can have their width altered by passing units via `--width`. e.g.
+  `gflabel cullenect --width 80mm` will make an exactly 80mm wide label, but
+  `gflabel cullenect -w 2` or `-w 2u` will continue generating labels that
+  match the standard.
 - Tweaked design of threaded insert fragment to look more like a threaded insert.
 - All labels can have their height altered with `--height`. Please be
   aware that this will likely make them incompatible with the label

--- a/src/gflabel/bases/__init__.py
+++ b/src/gflabel/bases/__init__.py
@@ -5,6 +5,8 @@ from abc import ABC, abstractmethod
 
 from build123d import Part, Vector
 
+from ..util import unit_registry
+
 
 class LabelBase(ABC):
     """
@@ -13,6 +15,12 @@ class LabelBase(ABC):
 
     part: Part
     area: Vector
+
+    # The width for this base to use if none is specified
+    DEFAULT_WIDTH = None
+    # The unit to use for the user-specified width if it was dimensionless
+    DEFAULT_WIDTH_UNIT = None
+    DEFAULT_MARGIN = unit_registry.Quantity(0.2, "mm")
 
     @classmethod
     def generate_argparse(
@@ -23,6 +31,9 @@ class LabelBase(ABC):
 
     @classmethod
     def validate_arguments(cls, args: argparse.Namespace) -> bool:
+        if not args.margin:
+            args.margin = cls.DEFAULT_MARGIN
+
         return True
 
     @abstractmethod

--- a/src/gflabel/bases/cullenect.py
+++ b/src/gflabel/bases/cullenect.py
@@ -196,7 +196,7 @@ class CullenectBase(LabelBase):
     def __init__(self, args: argparse.Namespace):
         version = args.version or "latest"
         width = args.width
-        height_mm = args.height
+        height_mm = args.height.to("mm").magnitude if args.height is not None else None
 
         known_versions = {"latest", "v1.1", "v2.0.0", "v2+"}
         if version == "latest":

--- a/src/gflabel/bases/modern.py
+++ b/src/gflabel/bases/modern.py
@@ -74,7 +74,10 @@ class ModernBase(LabelBase):
 
         with unit_registry.context("u", fn=_convert_u_to_mm):
             W_mm = args.width.to("mm").magnitude
-        H_mm = args.height or 22.117157  # I cannot work out the basis for this value
+        H_mm = 22.117157  # I cannot work out the basis for this value
+        if args.height is not None:
+            H_mm = args.height.to("mm").magnitude
+
         depth = 2.2
 
         # Label constructed by angled extrusion of inner sketch

--- a/src/gflabel/bases/modern.py
+++ b/src/gflabel/bases/modern.py
@@ -7,9 +7,11 @@ https://www.printables.com/model/894202-modern-gridfinity-case
 from __future__ import annotations
 
 import argparse
+import logging
 import math
 import sys
 
+import pint
 from build123d import (
     Align,
     Axis,
@@ -30,7 +32,10 @@ from build123d import (
     mirror,
 )
 
+from ..util import unit_registry
 from . import LabelBase
+
+logger = logging.getLogger(__name__)
 
 
 class ModernBase(LabelBase):
@@ -43,34 +48,38 @@ class ModernBase(LabelBase):
 
     def __init__(self, args: argparse.Namespace):
         # Temporary: Pull these out of the args without checking
-        width = args.width
-        height_mm = args.height
+        # width = args.width
+        # height_mm = args.height
 
+        KNOWN_WIDTHS = {3: 31.8, 4: 50.8, 5: 75.8, 6: 115.8, 7: 140.800, 8: 140.800}
+        # Tolerance factor to shrink the width by
         EXTRA_WIDTH_TOL = 0.5
+
+        # The indent is 15.8mm narrower than the label width
+        INDENT_WIDTH_MARGINS = 15.8
+        # Tolerance factor to enlarge the indent width by
         EXTRA_INDENT_TOL = 0.4
         INDENT_DEPTH = 0.6 + 0.2
-        KNOWN_WIDTHS = {3: 31.8, 4: 50.8, 5: 75.8, 6: 115.8, 7: 140.800, 8: 140.800}
-        KNOWN_INDENT_WIDTHS = {
-            3: 16,
-            4: 35,
-            5: 60,
-            6: 100,
-            7: 125,
-            8: 125,
-        }
 
-        if width not in KNOWN_WIDTHS:
-            sys.exit(
-                f"Error: Do not know how wide to create 'modern' label for {width} u"
+        def _convert_u_to_mm(u: pint.Quantity):
+            if u.magnitude not in KNOWN_WIDTHS:
+                logger.error(
+                    "'Modern' label u-dimensions only known for 3u-8u boxes. Specify mm for custom sizes."
+                )
+                sys.exit(1)
+            return pint.Quantity(
+                KNOWN_WIDTHS[u.magnitude] - EXTRA_WIDTH_TOL,
+                "mm",
             )
 
-        W = KNOWN_WIDTHS[width] - EXTRA_WIDTH_TOL
-        H = height_mm or 22.117157  # I cannot work out the basis for this value
+        with unit_registry.context("u", fn=_convert_u_to_mm):
+            W_mm = args.width.to("mm").magnitude
+        H_mm = args.height or 22.117157  # I cannot work out the basis for this value
         depth = 2.2
 
         # Label constructed by angled extrusion of inner sketch
-        W_inner = W - depth
-        H_inner = H - depth
+        W_inner = W_mm - depth
+        H_inner = H_mm - depth
 
         with BuildPart() as part:
             with BuildSketch(Plane.XY.offset(amount=-depth / 2)) as _sketch:
@@ -92,8 +101,13 @@ class ModernBase(LabelBase):
 
             # Add the flattened base
             with BuildPart(mode=Mode.PRIVATE) as _bottom_part:
-                with Locations([(0, -H / 2, -depth / 2)]):
-                    Box(W, depth, depth, align=(Align.CENTER, Align.MIN, Align.CENTER))
+                with Locations([(0, -H_mm / 2, -depth / 2)]):
+                    Box(
+                        W_mm,
+                        depth,
+                        depth,
+                        align=(Align.CENTER, Align.MIN, Align.CENTER),
+                    )
 
                     edges = (
                         _bottom_part.edges(Select.LAST)
@@ -105,9 +119,9 @@ class ModernBase(LabelBase):
 
             # Add the indent
             # 60mm x 13mm, 4.7m from bottom
-            with Locations([(0, -H / 2 + 4.7, -depth)]):
+            with Locations([(0, -H_mm / 2 + 4.7, -depth)]):
                 Box(
-                    KNOWN_INDENT_WIDTHS[width] + EXTRA_INDENT_TOL,
+                    W_mm - INDENT_WIDTH_MARGINS + EXTRA_INDENT_TOL,
                     13,
                     INDENT_DEPTH,
                     mode=Mode.SUBTRACT,
@@ -115,4 +129,4 @@ class ModernBase(LabelBase):
                 )
 
         self.part = part.part
-        self.area = Vector(W, H)
+        self.area = Vector(W_mm, H_mm)

--- a/src/gflabel/bases/none.py
+++ b/src/gflabel/bases/none.py
@@ -35,6 +35,6 @@ class NoneBase(LabelBase):
                 "Error: Can only generate 'Embossed' style labels without a base."
             )
             sys.exit(1)
-        if not args.height:
-            args.height = 15
+        if args.height is None:
+            args.height = unit_registry.Quantity(15, "mm")
         return super().validate_arguments(args)

--- a/src/gflabel/bases/none.py
+++ b/src/gflabel/bases/none.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+
+from ..options import LabelStyle
+from ..util import unit_registry
+from . import LabelBase
+
+logger = logging.getLogger(__name__)
+
+
+class NoneBase(LabelBase):
+    DEFAULT_WIDTH = None
+    DEFAULT_WIDTH_UNIT = unit_registry.mm
+
+    def __init__(self, args: argparse.Namespace):
+        self.part = None
+        self.area = None
+
+    @classmethod
+    def validate_arguments(cls, args):
+        if args.width is None:
+            sys.exit("Error: Must specify a width for 'None' labels")
+        if args.width.units == unit_registry.u:
+            sys.exit("Error: Cannot specify width in gridfinity units for empty base")
+        if not args.width.check("[length]"):
+            sys.exit(
+                f"Error: Invalid unit for 'None' width: {args.width.u}. Try '30mm'"
+            )
+        # We cannot have debossed labels with no label
+        if args.base == "none" and args.style != LabelStyle.EMBOSSED:
+            logger.error(
+                "Error: Can only generate 'Embossed' style labels without a base."
+            )
+            sys.exit(1)
+        if not args.height:
+            args.height = 15
+        return super().validate_arguments(args)

--- a/src/gflabel/bases/plain.py
+++ b/src/gflabel/bases/plain.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
 import argparse
+import logging
+import sys
 
 from build123d import Axis, BuildPart, BuildSketch, Rectangle, Vector, extrude, fillet
 
+from ..util import unit_registry
 from . import LabelBase
+
+logger = logging.getLogger(__name__)
 
 
 class PlainBase(LabelBase):
@@ -22,8 +27,23 @@ class PlainBase(LabelBase):
 
     """
 
+    DEFAULT_WIDTH = None
+    DEFAULT_WIDTH_UNIT = unit_registry.mm
+
+    @classmethod
+    def validate_arguments(cls, args):
+        if args.width < 10:
+            logger.warning(
+                f"Warning: Small width ({args.width}) for plain base. Did you specify in mm?"
+            )
+        if not args.height:
+            args.height = 15
+        return super().validate_arguments(args)
+
     def __init__(self, args: argparse.Namespace):
-        width_mm = args.width
+        if args.width.units == unit_registry.u:
+            sys.exit("Error: Cannot specify width in units for plain base")
+        width_mm = args.width.to("mm").magnitude
         height = args.height
         with BuildPart() as part:
             with BuildSketch() as _sketch:

--- a/src/gflabel/bases/plain.py
+++ b/src/gflabel/bases/plain.py
@@ -37,17 +37,17 @@ class PlainBase(LabelBase):
                 f"Warning: Small width ({args.width}) for plain base. Did you specify in mm?"
             )
         if not args.height:
-            args.height = 15
+            args.height = unit_registry.Quantity(15, unit_registry.mm)
         return super().validate_arguments(args)
 
     def __init__(self, args: argparse.Namespace):
         if args.width.units == unit_registry.u:
             sys.exit("Error: Cannot specify width in units for plain base")
         width_mm = args.width.to("mm").magnitude
-        height = args.height
+        height_mm = args.height.to("mm").magnitude
         with BuildPart() as part:
             with BuildSketch() as _sketch:
-                Rectangle(width_mm, height=height)
+                Rectangle(width_mm, height=height_mm)
             # Extrude the base up
             extrude(amount=-0.8)
 
@@ -59,4 +59,4 @@ class PlainBase(LabelBase):
             fillet(fillet_edges, radius=0.2)
 
         self.part = part.part
-        self.area = Vector(width_mm, height)
+        self.area = Vector(width_mm, height_mm)

--- a/src/gflabel/bases/pred.py
+++ b/src/gflabel/bases/pred.py
@@ -118,8 +118,9 @@ class PredBase(LabelBase):
             width_mm = args.width.to("mm").magnitude
 
         recessed = args.style == LabelStyle.EMBOSSED
-        height_mm = args.height
-        height_mm = height_mm or 11.5
+        height_mm = 11.5
+        if args.height is not None:
+            height_mm = args.height.to("mm").magnitude
 
         with BuildPart() as part:
             add(_outer_edge(width_mm=width_mm, height_mm=height_mm))
@@ -153,8 +154,6 @@ class PredBoxBase(LabelBase):
     DEFAULT_MARGIN = unit_registry.Quantity(3, "mm")
 
     def __init__(self, args: argparse.Namespace):
-        height_mm = args.height
-
         def _convert_u_to_mm(u: pint.Quantity):
             if args.width.magnitude not in {4, 5, 6, 7}:
                 logger.error(
@@ -177,14 +176,16 @@ class PredBoxBase(LabelBase):
         r_edge = 3.5
         depth = 0.85
         chamfer_d = 0.2
-        height = height_mm or 24.5
+        height_mm = 24.5
+        if args.height is not None:
+            height_mm = args.height.to("mm").magnitude
 
         with BuildPart() as part:
             with BuildSketch() as sketch:
-                RectangleRounded(width_mm, height, r_edge)
+                RectangleRounded(width_mm, height_mm, r_edge)
             extrude(sketch.sketch, -depth)
 
             chamfer(part.faces().filter_by(Plane.XY).edges(), chamfer_d)
 
         self.part = part.part
-        self.area = Vector(width_mm - chamfer_d * 2, height - chamfer_d * 2)
+        self.area = Vector(width_mm - chamfer_d * 2, height_mm - chamfer_d * 2)

--- a/src/gflabel/bases/pred.py
+++ b/src/gflabel/bases/pred.py
@@ -4,6 +4,7 @@ import argparse
 import logging
 import sys
 
+import pint
 from build123d import (
     Axis,
     BuildLine,
@@ -30,18 +31,19 @@ from build123d import (
 
 from gflabel.options import LabelStyle
 
+from ..util import unit_registry
 from . import LabelBase
 
 logger = logging.getLogger(__name__)
 
 
-def _outer_edge(width_u: int, height_mm: float) -> Sketch:
+def _outer_edge(width_mm: float, height_mm: float) -> Sketch:
     """Generate the outer edge profile of a pred-label"""
     # Width of straight bit in label is:
     #   Bin width (u * 42)
     # - label margins (4.2mm)
     # - label end size (1.9mm per end)
-    straight_width = width_u * 42 - 4.2 - (1.9 * 2)
+    straight_width = width_mm - (1.9 * 2)
     with BuildSketch() as sketch:
         with BuildLine() as line:
             # Where the sketch is placed in X. 2.1 is the pred label offset
@@ -68,8 +70,8 @@ def _outer_edge(width_u: int, height_mm: float) -> Sketch:
     return sketch.sketch
 
 
-def _inner_edge(width_u: int, height_mm: float) -> Sketch:
-    straight_width = width_u * 42 - 4.2 - (1.9 * 2)
+def _inner_edge(width_mm: float, height_mm: float) -> Sketch:
+    straight_width = width_mm - (1.9 * 2)
     x = -straight_width / 2
     with BuildSketch() as sketch:
         with BuildLine() as line:
@@ -101,20 +103,31 @@ class PredBase(LabelBase):
             for embossing) or just flat, for cutting away.
     """
 
+    DEFAULT_WIDTH = pint.Quantity("1u")
+    DEFAULT_WIDTH_UNIT = unit_registry.u
+
     def __init__(self, args: argparse.Namespace):
-        pass
+        assert args.width.check(unit_registry.u) or args.width.check("[length]")
+
+        def _convert_u_to_mm(u):
+            return u * unit_registry.Quantity("42mm/u") - unit_registry.Quantity(
+                "4.2mm"
+            )
+
+        with unit_registry.context("u", fn=_convert_u_to_mm):
+            width_mm = args.width.to("mm").magnitude
+
         recessed = args.style == LabelStyle.EMBOSSED
-        width_u = args.width
         height_mm = args.height
         height_mm = height_mm or 11.5
 
         with BuildPart() as part:
-            add(_outer_edge(width_u=width_u, height_mm=height_mm))
+            add(_outer_edge(width_mm=width_mm, height_mm=height_mm))
             # Extrude the base up
             extrude(amount=0.4, both=True)
 
             if recessed:
-                add(_inner_edge(width_u=width_u, height_mm=height_mm))
+                add(_inner_edge(width_mm=width_mm, height_mm=height_mm))
                 # Cut the indent out of the top face
                 extrude(amount=0.4, mode=Mode.SUBTRACT)
 
@@ -125,7 +138,7 @@ class PredBase(LabelBase):
             ]
             fillet(fillet_edges, radius=0.2)
 
-        self.area = Vector(width_u * 42 - 4.2 - 5.5, height_mm - 1)
+        self.area = Vector(width_mm - 5.5, height_mm - 1)
 
         if recessed:
             self.part = part.part
@@ -135,31 +148,43 @@ class PredBase(LabelBase):
 
 
 class PredBoxBase(LabelBase):
+    DEFAULT_WIDTH = None
+    DEFAULT_WIDTH_UNIT = unit_registry.u
+    DEFAULT_MARGIN = unit_registry.Quantity(3, "mm")
+
     def __init__(self, args: argparse.Namespace):
-        width_u = args.width
         height_mm = args.height
 
-        if width_u not in {4, 5, 6, 7}:
-            logger.error(
-                "Pred box label dimensions only known for 4u, 5u, 6u and 7u boxes"
+        def _convert_u_to_mm(u: pint.Quantity):
+            if args.width.magnitude not in {4, 5, 6, 7}:
+                logger.error(
+                    "Pred box label dimensions only known for 4u, 5u, 6u and 7u boxes"
+                )
+                sys.exit(1)
+            return pint.Quantity(
+                {
+                    4: 25.5,
+                    5: 67.5,
+                    6: 82,
+                    7: 82,
+                }[u.magnitude],
+                "mm",
             )
-            sys.exit(1)
+
+        with unit_registry.context("u", fn=_convert_u_to_mm):
+            width_mm = args.width.to("mm").magnitude
+
         r_edge = 3.5
         depth = 0.85
         chamfer_d = 0.2
         height = height_mm or 24.5
-        width = {
-            4: 25.5,
-            5: 67.5,
-            6: 82,
-            7: 82,
-        }[width_u]
+
         with BuildPart() as part:
             with BuildSketch() as sketch:
-                RectangleRounded(width, height, r_edge)
+                RectangleRounded(width_mm, height, r_edge)
             extrude(sketch.sketch, -depth)
 
             chamfer(part.faces().filter_by(Plane.XY).edges(), chamfer_d)
 
         self.part = part.part
-        self.area = Vector(width - chamfer_d * 2, height - chamfer_d * 2)
+        self.area = Vector(width_mm - chamfer_d * 2, height - chamfer_d * 2)

--- a/src/gflabel/cli.py
+++ b/src/gflabel/cli.py
@@ -353,9 +353,13 @@ def run(argv: list[str] | None = None):
             label_area = body.area
         else:
             # Only occurs if label type has no body e.g. "None"
-            y_offset_each_label = args.height + args.label_gap
+            if args.height is None:
+                args.height = pint.Quantity("12mm")
+            y_offset_each_label = args.height.to("mm").magnitude + args.label_gap
 
-            label_area = Vector(X=args.width, Y=args.height)
+            label_area = Vector(
+                X=args.width.to("mm").magnitude, Y=args.height.to("mm").magnitude
+            )
 
         body_locations = []
         with BuildSketch(mode=Mode.PRIVATE) as label_sketch:

--- a/src/gflabel/cli.py
+++ b/src/gflabel/cli.py
@@ -175,16 +175,16 @@ def run(argv: list[str] | None = None):
     parser.add_argument(
         "-w",
         "--width",
-        help="Label width. If using a gridfinity standard base, then this is width in U. Otherwise, width in mm.",
+        help="Label width. If using a gridfinity standard base, then this is width in U. Otherwise, width in mm. Specify units e.g. '3mm' to override the default behaviour.",
         metavar="WIDTH",
         type=pint.Quantity,
     )
     parser.add_argument(
         "--height",
-        help="Label height, in mm. For bases with standard heights, this will overwrite the height, diverging from the standard.",
+        help="Label height, by default in mm. For bases with standard heights, this will overwrite the height, diverging from the standard.",
         metavar="HEIGHT",
         default=None,
-        type=float,
+        type=pint.Quantity,
     )
     parser.add_argument(
         "--depth",
@@ -327,6 +327,9 @@ def run(argv: list[str] | None = None):
     # If we got a dimensionless width, replace with the base default unit
     if args.width.units == unit_registry.dimensionless:
         args.width = pint.Quantity(args.width.magnitude, base_type.DEFAULT_WIDTH_UNIT)
+    # Height with unspecified units is mm
+    if args.height and args.height.units == unit_registry.dimensionless:
+        args.height = pint.Quantity(args.height.magnitude, unit_registry.mm)
 
     if args.margin is None:
         args.margin = base_type.DEFAULT_MARGIN

--- a/src/gflabel/fragments.py
+++ b/src/gflabel/fragments.py
@@ -231,6 +231,8 @@ class TextFragment(Fragment):
         self.text = text
 
     def render(self, height: float, maxsize: float, options: RenderOptions) -> Sketch:
+        if not height:
+            raise ValueError("Trying to render zero-height text fragment")
         with BuildSketch() as sketch:
             with options.font.font_options() as f:
                 print(f"Using {f}")

--- a/src/gflabel/util.py
+++ b/src/gflabel/util.py
@@ -6,7 +6,24 @@ from collections.abc import Mapping
 from itertools import islice
 from typing import Any, Callable, Sequence
 
+import pint
 from rich.logging import RichHandler
+
+unit_registry = pint.UnitRegistry()
+unit_registry.define("u = []")
+# Add a custom transformation to this registry
+ctx = pint.Context("u")
+ctx.add_transformation(
+    "u",
+    "[length]",
+    lambda ureg, x, fn: fn(x),
+    # * ureg.Quantity(fn(x) / ureg.Quantity("u")),
+)
+unit_registry.add_context(ctx)
+
+# Use this by default
+# unit_registry.enable_contexts("u")
+pint.set_application_registry(unit_registry)
 
 
 # Taken from Python 3.12 documentation.


### PR DESCRIPTION
This enables all label bases to take units in the width parameter, e.g. `--width 3`, `--width 4u`, `--width 30mm`, `--width 4in`. Labels which have defined standard sizes will accept plain or -u units, but specifying exact width for any label will  mean the label is generated at exactly that width.

The default unit, if you do not specify, is a property of each base e.g. `pred` or `cullenect` will by default assume `-u`, but `plain` bases will assume millimeters (and won't accept u-units).

Added upon request from @Marus - does this do what you wanted?