### PR TITLE
Fixed drive aliases

### DIFF
--- a/src/gflabel/fragments.py
+++ b/src/gflabel/fragments.py
@@ -488,6 +488,7 @@ class BoltBase(Fragment):
         self.partial = "partial" in self.modifiers
         features -= self.MODIFIERS
 
+        features = {DRIVE_ALIASES.get(x.lower(), x.lower()) for x in features}
         # Drives is everything left
         self.drives = features
 


### PR DESCRIPTION
The following command would error
```sh
gflabel cullenect --vscode --font-path "osifont.ttf" --font-size-maximum 9 "{...}#8×1¼{...}{cullbolt(tapping,partial,round,square)}" -o nr8x1-14-square-round-tapping-partial.step
```
Stating that there are 2 head types defined. Apparently square is an alias for socket head type, but square is also a drive type.

The real fix is probably removing square as an alias for socket, but for now I've fixed the missing drive type alias (was not implemented. So now I can use "robertson" to get a square drive with a round head.

This works now, robertson was not recognized previously:
```sh
gflabel cullenect --vscode --font-path "osifont.ttf" --font-size-maximum 9 "{...}#8×1¼{...}{cullbolt(tapping,partial,round,robertson)}" -o nr8x1-14-square-round-tapping-partial.step
```

<img width="1263" height="441" alt="image" src="https://github.com/user-attachments/assets/8652d7f2-c5f3-42b3-bdae-744f6b489267" />
